### PR TITLE
Add deprecated modules on `0.60`

### DIFF
--- a/src/__testfixtures__/MultipleImports.input.js
+++ b/src/__testfixtures__/MultipleImports.input.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { AsyncStorage, Image } from "react-native";
+import { AsyncStorage, Image, Geolocation, CheckBox } from "react-native";
 
 const MyComponent = () => {};
 

--- a/src/__testfixtures__/MultipleImports.output.js
+++ b/src/__testfixtures__/MultipleImports.output.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { Image } from "react-native";
 
+import { CheckBox } from "@react-native-community/checkbox";
+import Geolocation from "@react-native-community/geolocation";
 import AsyncStorage from "@react-native-community/async-storage";
 
 const MyComponent = () => {};

--- a/src/codemod.js
+++ b/src/codemod.js
@@ -30,6 +30,14 @@ const DEPRECATED_MODULES = {
     newPackageName: 'react-native-webview',
     specifier: 'importSpecifier',
   },
+  Geolocation: {
+    newPackageName: getModuleNameWithOrg('geolocation'),
+    specifier: 'importDefaultSpecifier',
+  },
+  CheckBox: {
+    newPackageName: getModuleNameWithOrg('checkbox'),
+    specifier: 'importSpecifier',
+  },
 };
 
 let addedPackages = [];


### PR DESCRIPTION
Waiting for react-native-community/releases#120 to kick in.